### PR TITLE
Add ps2 binutils to mwcps2 compilers

### DIFF
--- a/platforms/ps2/mwcps2-3.0-011126/Dockerfile
+++ b/platforms/ps2/mwcps2-3.0-011126/Dockerfile
@@ -7,6 +7,8 @@ RUN mkdir -p /compilers/ps2/mwcps2-3.0-011126
 
 RUN wget -O mwcps2-3.0-011126.tar.gz "https://github.com/decompme/compilers/releases/download/compilers/mwcps2-3.0-011126.tar.gz"
 RUN tar xvzf mwcps2-3.0-011126.tar.gz -C /compilers/ps2/mwcps2-3.0-011126
+RUN wget -O binutils-mips-ps2-decompals-linux-x86-64.tar.gz "https://github.com/decompals/binutils-mips-ps2-decompals/releases/download/v0.1/binutils-mips-ps2-decompals-linux-x86-64.tar.gz"
+RUN tar xvzf binutils-mips-ps2-decompals-linux-x86-64.tar.gz -C /compilers/ps2/mwcps2-3.0-011126
 
 RUN chown -R root:root /compilers/ps2/mwcps2-3.0-011126/
 RUN chmod +x /compilers/ps2/mwcps2-3.0-011126/*

--- a/platforms/ps2/mwcps2-3.0.1-020123/Dockerfile
+++ b/platforms/ps2/mwcps2-3.0.1-020123/Dockerfile
@@ -7,6 +7,8 @@ RUN mkdir -p /compilers/ps2/mwcps2-3.0.1-020123
 
 RUN wget -O mwcps2-3.0.1-020123.tar.gz "https://github.com/decompme/compilers/releases/download/compilers/mwcps2-3.0.1-020123.tar.gz"
 RUN tar xvzf mwcps2-3.0.1-020123.tar.gz -C /compilers/ps2/mwcps2-3.0.1-020123
+RUN wget -O binutils-mips-ps2-decompals-linux-x86-64.tar.gz "https://github.com/decompals/binutils-mips-ps2-decompals/releases/download/v0.1/binutils-mips-ps2-decompals-linux-x86-64.tar.gz"
+RUN tar xvzf binutils-mips-ps2-decompals-linux-x86-64.tar.gz -C /compilers/ps2/mwcps2-3.0.1-020123
 
 RUN chown -R root:root /compilers/ps2/mwcps2-3.0.1-020123/
 RUN chmod +x /compilers/ps2/mwcps2-3.0.1-020123/*

--- a/platforms/ps2/mwcps2-3.0.3-020716/Dockerfile
+++ b/platforms/ps2/mwcps2-3.0.3-020716/Dockerfile
@@ -7,6 +7,8 @@ RUN mkdir -p /compilers/ps2/mwcps2-3.0.3-020716
 
 RUN wget -O mwcps2-3.0.3-020716.tar.gz "https://github.com/decompme/compilers/releases/download/compilers/mwcps2-3.0.3-020716.tar.gz"
 RUN tar xvzf mwcps2-3.0.3-020716.tar.gz -C /compilers/ps2/mwcps2-3.0.3-020716
+RUN wget -O binutils-mips-ps2-decompals-linux-x86-64.tar.gz "https://github.com/decompals/binutils-mips-ps2-decompals/releases/download/v0.1/binutils-mips-ps2-decompals-linux-x86-64.tar.gz"
+RUN tar xvzf binutils-mips-ps2-decompals-linux-x86-64.tar.gz -C /compilers/ps2/mwcps2-3.0.3-020716
 
 RUN chown -R root:root /compilers/ps2/mwcps2-3.0.3-020716/
 RUN chmod +x /compilers/ps2/mwcps2-3.0.3-020716/*

--- a/values.yaml
+++ b/values.yaml
@@ -258,15 +258,24 @@ compilers:
   - id: mwcps2-3.0-011126
     platform: ps2
     template: common/default
-    file: https://github.com/decompme/compilers/releases/download/compilers/mwcps2-3.0-011126.tar.gz
+    files:
+      - https://github.com/decompme/compilers/releases/download/compilers/mwcps2-3.0-011126.tar.gz
+      - https://github.com/decompals/binutils-mips-ps2-decompals/releases/download/v0.1/binutils-mips-ps2-decompals-linux-x86-64.tar.gz
+
   - id: mwcps2-3.0.1-020123
     platform: ps2
     template: common/default
-    file: https://github.com/decompme/compilers/releases/download/compilers/mwcps2-3.0.1-020123.tar.gz
+    files:
+      - https://github.com/decompme/compilers/releases/download/compilers/mwcps2-3.0.1-020123.tar.gz
+      - https://github.com/decompals/binutils-mips-ps2-decompals/releases/download/v0.1/binutils-mips-ps2-decompals-linux-x86-64.tar.gz
+
   - id: mwcps2-3.0.3-020716
     platform: ps2
     template: common/default
-    file: https://github.com/decompme/compilers/releases/download/compilers/mwcps2-3.0.3-020716.tar.gz
+    files:
+      - https://github.com/decompme/compilers/releases/download/compilers/mwcps2-3.0.3-020716.tar.gz
+      - https://github.com/decompals/binutils-mips-ps2-decompals/releases/download/v0.1/binutils-mips-ps2-decompals-linux-x86-64.tar.gz
+      
   - id: mwcps2-3.0b22-020926
     platform: ps2
     template: common/xz


### PR DESCRIPTION
mwcps2-2.3-991202 and mwcps2-3.0b22-020926 should use ps2 binutils too but I'm usure if I can use common/default vs common/xz for those