### PR TITLE
Add decompals fork of EGCS 1.1.2-4

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,8 +14,8 @@ The values that are used to populate the templates are found in values.yaml.
 Rather than modifying the Dockerfiles directly, the `.j2` template should be changed and the Dockerfiles regenerated.
 
 ```sh
-python3 -m pip install Jinja2
-python3 template.py
+python3 -m pip install Jinja2 pyyaml
+python3 template.py values.yaml
 ```
 
 ## Notes:

--- a/platforms/n64/egcs_1.1.2-4c/darwin/Dockerfile
+++ b/platforms/n64/egcs_1.1.2-4c/darwin/Dockerfile
@@ -1,0 +1,19 @@
+# NOTE: This file is generated automatically via template.py. Do not edit manually!
+
+
+FROM alpine:3.18 as base
+
+RUN mkdir -p /compilers/n64/egcs_1.1.2-4c
+
+RUN wget -O mips-binutils-egcs-2.9.5-macos.tar.gz "https://github.com/decompals/mips-binutils-egcs-2.9.5/releases/download/0.6/mips-binutils-egcs-2.9.5-macos.tar.gz"
+RUN tar xvzf mips-binutils-egcs-2.9.5-macos.tar.gz -C /compilers/n64/egcs_1.1.2-4c
+RUN wget -O mips-gcc-egcs-2.91.66-macos.tar.gz "https://github.com/decompals/mips-gcc-egcs-2.91.66/releases/download/0.7/mips-gcc-egcs-2.91.66-macos.tar.gz"
+RUN tar xvzf mips-gcc-egcs-2.91.66-macos.tar.gz -C /compilers/n64/egcs_1.1.2-4c
+
+RUN chown -R root:root /compilers/n64/egcs_1.1.2-4c/
+RUN chmod +x /compilers/n64/egcs_1.1.2-4c/*
+
+
+FROM scratch as release
+
+COPY --from=base /compilers /compilers

--- a/platforms/n64/egcs_1.1.2-4c/linux/Dockerfile
+++ b/platforms/n64/egcs_1.1.2-4c/linux/Dockerfile
@@ -1,0 +1,19 @@
+# NOTE: This file is generated automatically via template.py. Do not edit manually!
+
+
+FROM alpine:3.18 as base
+
+RUN mkdir -p /compilers/n64/egcs_1.1.2-4c
+
+RUN wget -O mips-binutils-egcs-2.9.5-linux.tar.gz "https://github.com/decompals/mips-binutils-egcs-2.9.5/releases/download/0.6/mips-binutils-egcs-2.9.5-linux.tar.gz"
+RUN tar xvzf mips-binutils-egcs-2.9.5-linux.tar.gz -C /compilers/n64/egcs_1.1.2-4c
+RUN wget -O mips-gcc-egcs-2.91.66-linux.tar.gz "https://github.com/decompals/mips-gcc-egcs-2.91.66/releases/download/0.7/mips-gcc-egcs-2.91.66-linux.tar.gz"
+RUN tar xvzf mips-gcc-egcs-2.91.66-linux.tar.gz -C /compilers/n64/egcs_1.1.2-4c
+
+RUN chown -R root:root /compilers/n64/egcs_1.1.2-4c/
+RUN chmod +x /compilers/n64/egcs_1.1.2-4c/*
+
+
+FROM scratch as release
+
+COPY --from=base /compilers /compilers

--- a/values.yaml
+++ b/values.yaml
@@ -101,6 +101,21 @@ compilers:
     template: common/default
     file: https://github.com/AngheloAlf/egcs_1.1.2-4/releases/download/latest/egcs_1.1.2-4.tar.gz
 
+  - id: egcs_1.1.2-4c
+    platform: n64
+    template: common/default
+    arch: linux
+    files:
+      - https://github.com/decompals/mips-binutils-egcs-2.9.5/releases/download/0.6/mips-binutils-egcs-2.9.5-linux.tar.gz
+      - https://github.com/decompals/mips-gcc-egcs-2.91.66/releases/download/0.7/mips-gcc-egcs-2.91.66-linux.tar.gz
+  - id: egcs_1.1.2-4c
+    platform: n64
+    template: common/default
+    arch: darwin
+    files:
+      - https://github.com/decompals/mips-binutils-egcs-2.9.5/releases/download/0.6/mips-binutils-egcs-2.9.5-macos.tar.gz
+      - https://github.com/decompals/mips-gcc-egcs-2.91.66/releases/download/0.7/mips-gcc-egcs-2.91.66-macos.tar.gz
+
   - id: gcc4.4.0-mips64-elf
     platform: n64
     template: common/default


### PR DESCRIPTION
This has some new features over the stock version (e.g. anonymous unions) which we'd like to use for OoT iQue.

I don't really know what to call this. The current one is called "EGCS 1.1.2-4 (gcc egcs-2.91.66)" so maybe "EGCS 1.1.2-4 (gcc egcs-2.91.66, custom)"? What would be a good name here?