### PR TITLE
Add more PS2 compilers

### DIFF
--- a/platforms/ps2/ee-gcc3.2-030210-beta2/Dockerfile
+++ b/platforms/ps2/ee-gcc3.2-030210-beta2/Dockerfile
@@ -1,0 +1,17 @@
+# NOTE: This file is generated automatically via template.py. Do not edit manually!
+
+
+FROM alpine:3.18 as base
+
+RUN mkdir -p /compilers/ps2/ee-gcc3.2-030210-beta2
+
+RUN wget -O ee-gcc3.2-030210-beta2.tar.gz "https://github.com/decompme/compilers/releases/download/compilers/ee-gcc3.2-030210-beta2.tar.gz"
+RUN tar xvzf ee-gcc3.2-030210-beta2.tar.gz -C /compilers/ps2/ee-gcc3.2-030210-beta2
+
+RUN chown -R root:root /compilers/ps2/ee-gcc3.2-030210-beta2/
+RUN chmod +x /compilers/ps2/ee-gcc3.2-030210-beta2/*
+
+
+FROM scratch as release
+
+COPY --from=base /compilers /compilers

--- a/platforms/ps2/ee-gcc3.2-030926/Dockerfile
+++ b/platforms/ps2/ee-gcc3.2-030926/Dockerfile
@@ -1,0 +1,17 @@
+# NOTE: This file is generated automatically via template.py. Do not edit manually!
+
+
+FROM alpine:3.18 as base
+
+RUN mkdir -p /compilers/ps2/ee-gcc3.2-030926
+
+RUN wget -O ee-gcc3.2-030926.tar.gz "https://github.com/decompme/compilers/releases/download/compilers/ee-gcc3.2-030926.tar.gz"
+RUN tar xvzf ee-gcc3.2-030926.tar.gz -C /compilers/ps2/ee-gcc3.2-030926
+
+RUN chown -R root:root /compilers/ps2/ee-gcc3.2-030926/
+RUN chmod +x /compilers/ps2/ee-gcc3.2-030926/*
+
+
+FROM scratch as release
+
+COPY --from=base /compilers /compilers

--- a/platforms/ps2/iop-gcc2.8.1/Dockerfile
+++ b/platforms/ps2/iop-gcc2.8.1/Dockerfile
@@ -1,0 +1,17 @@
+# NOTE: This file is generated automatically via template.py. Do not edit manually!
+
+
+FROM alpine:3.18 as base
+
+RUN mkdir -p /compilers/ps2/iop-gcc2.8.1
+
+RUN wget -O iop-gcc2.8.1.tar.gz "https://github.com/decompme/compilers/releases/download/compilers/iop-gcc2.8.1.tar.gz"
+RUN tar xvzf iop-gcc2.8.1.tar.gz -C /compilers/ps2/iop-gcc2.8.1
+
+RUN chown -R root:root /compilers/ps2/iop-gcc2.8.1/
+RUN chmod +x /compilers/ps2/iop-gcc2.8.1/*
+
+
+FROM scratch as release
+
+COPY --from=base /compilers /compilers

--- a/platforms/ps2/iop-gcc2.95.2-102/Dockerfile
+++ b/platforms/ps2/iop-gcc2.95.2-102/Dockerfile
@@ -1,0 +1,17 @@
+# NOTE: This file is generated automatically via template.py. Do not edit manually!
+
+
+FROM alpine:3.18 as base
+
+RUN mkdir -p /compilers/ps2/iop-gcc2.95.2-102
+
+RUN wget -O iop-gcc2.95.2-102.tar.gz "https://github.com/decompme/compilers/releases/download/compilers/iop-gcc2.95.2-102.tar.gz"
+RUN tar xvzf iop-gcc2.95.2-102.tar.gz -C /compilers/ps2/iop-gcc2.95.2-102
+
+RUN chown -R root:root /compilers/ps2/iop-gcc2.95.2-102/
+RUN chmod +x /compilers/ps2/iop-gcc2.95.2-102/*
+
+
+FROM scratch as release
+
+COPY --from=base /compilers /compilers

--- a/values.yaml
+++ b/values.yaml
@@ -250,6 +250,14 @@ compilers:
     file: https://github.com/decompals/old-gcc/releases/download/0.12/gcc-2.95.2-psx.tar.gz
 
 # PS2
+  - id: iop-gcc2.8.1
+    platform: ps2
+    template: common/default
+    file: https://github.com/decompme/compilers/releases/download/compilers/iop-gcc2.8.1.tar.gz
+  - id: iop-gcc2.95.2-102
+    platform: ps2
+    template: common/default
+    file: https://github.com/decompme/compilers/releases/download/compilers/iop-gcc2.95.2-102.tar.gz
   - id: ee-gcc2.9-990721
     platform: ps2
     template: common/default
@@ -274,6 +282,14 @@ compilers:
     platform: ps2
     template: common/default
     file: https://github.com/decompme/compilers/releases/download/compilers/ee-gcc2.96.tar.xz
+  - id: ee-gcc3.2-030210-beta2
+    platform: ps2
+    template: common/default
+    file: https://github.com/decompme/compilers/releases/download/compilers/ee-gcc3.2-030210-beta2.tar.gz
+  - id: ee-gcc3.2-030926
+    platform: ps2
+    template: common/default
+    file: https://github.com/decompme/compilers/releases/download/compilers/ee-gcc3.2-030926.tar.gz
   - id: ee-gcc3.2-040921
     platform: ps2
     template: common/default


### PR DESCRIPTION
This PR adds 2 IOP compilers and 2 EE 3.2 compilers, the referenced files are:
- [iop-gcc2.8.1.tar.gz](https://github.com/user-attachments/files/18740633/iop-gcc2.8.1.tar.gz)
- [iop-gcc2.95.2-102.tar.gz](https://github.com/user-attachments/files/18740635/iop-gcc2.95.2-102.tar.gz)
- [ee-gcc3.2-030210-beta2.tar.gz](https://github.com/user-attachments/files/18740628/ee-gcc3.2-030210-beta2.tar.gz)
- [ee-gcc3.2-030926.tar.gz](https://github.com/user-attachments/files/18740631/ee-gcc3.2-030926.tar.gz)
