### PR TITLE
Add NGC ProDG compilers

### DIFF
--- a/platforms/gc_wii/prodg_35_b140/Dockerfile
+++ b/platforms/gc_wii/prodg_35_b140/Dockerfile
@@ -1,0 +1,17 @@
+# NOTE: This file is generated automatically via template.py. Do not edit manually!
+
+
+FROM alpine:3.18 as base
+
+RUN mkdir -p /compilers/gc_wii/prodg_35_b140
+
+RUN wget -O prodg_35_b140.tar.gz "https://github.com/decompme/compilers/releases/download/compilers/prodg_35_b140.tar.gz"
+RUN tar xvzf prodg_35_b140.tar.gz -C /compilers/gc_wii/prodg_35_b140
+
+RUN chown -R root:root /compilers/gc_wii/prodg_35_b140/
+RUN chmod +x /compilers/gc_wii/prodg_35_b140/*
+
+
+FROM scratch as release
+
+COPY --from=base /compilers /compilers

--- a/platforms/gc_wii/prodg_381/Dockerfile
+++ b/platforms/gc_wii/prodg_381/Dockerfile
@@ -1,0 +1,17 @@
+# NOTE: This file is generated automatically via template.py. Do not edit manually!
+
+
+FROM alpine:3.18 as base
+
+RUN mkdir -p /compilers/gc_wii/prodg_381
+
+RUN wget -O prodg_381.tar.gz "https://github.com/decompme/compilers/releases/download/compilers/prodg_381.tar.gz"
+RUN tar xvzf prodg_381.tar.gz -C /compilers/gc_wii/prodg_381
+
+RUN chown -R root:root /compilers/gc_wii/prodg_381/
+RUN chmod +x /compilers/gc_wii/prodg_381/*
+
+
+FROM scratch as release
+
+COPY --from=base /compilers /compilers

--- a/values.yaml
+++ b/values.yaml
@@ -872,10 +872,18 @@ compilers:
     platform: gc_wii
     template: common/default
     file: https://github.com/decompme/compilers/releases/download/compilers/prodg_35.tar.gz
+  - id: prodg_35_b140
+    platform: gc_wii
+    template: common/default
+    file: https://github.com/decompme/compilers/releases/download/compilers/prodg_35_b140.tar.gz
   - id: prodg_37
     platform: gc_wii
     template: common/default
     file: https://github.com/decompme/compilers/releases/download/compilers/prodg_37.tar.gz
+  - id: prodg_381
+    platform: gc_wii
+    template: common/default
+    file: https://github.com/decompme/compilers/releases/download/compilers/prodg_381.tar.gz
   - id: prodg_393
     platform: gc_wii
     template: common/default


### PR DESCRIPTION
This PR add ProDG 3.5 (build 140) and ProDG 3.8.1 compilers, the referenced files are:
[prodg_35_b140.tar.gz](https://github.com/user-attachments/files/18782048/prodg_35_b140.tar.gz)
[prodg_381.tar.gz](https://github.com/user-attachments/files/18782049/prodg_381.tar.gz)
