### PR TITLE
Add MSVC 8.0 (Patched) compiler

### DIFF
--- a/platforms/win32/msvc8.0p/Dockerfile
+++ b/platforms/win32/msvc8.0p/Dockerfile
@@ -1,0 +1,24 @@
+# NOTE: This file is generated automatically via template.py. Do not edit manually!
+
+
+FROM alpine:3.18 as base
+
+# download zip first to allow for Docker caching
+
+RUN wget -O 52c8293f8b8d6441c594cf096542290c17a4d70e.zip "https://github.com/widberg/msvc8.0/archive/52c8293f8b8d6441c594cf096542290c17a4d70e.zip"
+RUN unzip 52c8293f8b8d6441c594cf096542290c17a4d70e.zip
+
+RUN mkdir -p /compilers/win32/msvc8.0p/Bin
+RUN mkdir -p /compilers/win32/msvc8.0p/Include
+
+RUN cp -r msvc8.0-*/bin/*     /compilers/win32/msvc8.0p/Bin
+RUN cp -r msvc8.0-*/include/* /compilers/win32/msvc8.0p/Include
+RUN cp -r msvc8.0-*/PlatformSDK/Include/* /compilers/win32/msvc8.0p/Include
+
+RUN chown -R root:root /compilers/win32/msvc8.0p/
+RUN chmod +x /compilers/win32/msvc8.0p/Bin/*
+
+
+FROM scratch as release
+
+COPY --from=base /compilers /compilers

--- a/values.yaml
+++ b/values.yaml
@@ -983,6 +983,14 @@ compilers:
     include_dirs:
       - msvc8.0-*/include
       - msvc8.0-*/PlatformSDK/Include
+  - id: msvc8.0p
+    platform: win32
+    template: win32/msvc
+    file: https://github.com/widberg/msvc8.0/archive/52c8293f8b8d6441c594cf096542290c17a4d70e.zip
+    bin_dir: msvc8.0-*/bin
+    include_dirs:
+      - msvc8.0-*/include
+      - msvc8.0-*/PlatformSDK/Include
 
 # DREAMCAST
   - id: shc-v5.1r11


### PR DESCRIPTION
Same as the MSVC 8.0 compiler with `cl.exe`, `c1.dll`, `c1xx.dll`, and `c2.dll` patched. Patched compiler files hosted at https://github.com/widberg/msvc8.0/tree/msvc8.0p. Patching program hosted at https://github.com/widberg/msvc8.0_patcher.