### PR TITLE
Use Python inline script metadata for template.py

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,8 +14,14 @@ The values that are used to populate the templates are found in values.yaml.
 Rather than modifying the Dockerfiles directly, the `.j2` template should be changed and the Dockerfiles regenerated.
 
 ```sh
+uv run template.py
+```
+
+Or, if you don't have `uv` installed:
+
+```sh
 python3 -m pip install Jinja2 pyyaml
-python3 template.py values.yaml
+python3 template.py
 ```
 
 ## Notes:

--- a/template.py
+++ b/template.py
@@ -1,3 +1,11 @@
+#!/usr/bin/env -S uv run --script
+# /// script
+# requires-python = ">=3.12"
+# dependencies = [
+#     "jinja2",
+#     "pyyaml",
+# ]
+# ///
 import argparse
 from pathlib import Path
 
@@ -10,7 +18,9 @@ def main():
     parser = argparse.ArgumentParser()
     parser.add_argument(
         "filename",
-        type=argparse.FileType("r"),
+        type=Path,
+        nargs="?",
+        default=Path("values.yaml"),
         help="Configuration file, e.g. `values.yaml`",
     )
     parser.add_argument(
@@ -33,7 +43,8 @@ def main():
         loader=FileSystemLoader(args.template_dir), autoescape=select_autoescape()
     )
 
-    values = yaml.safe_load(args.filename)
+    with args.filename.open("r") as f:
+        values = yaml.safe_load(f)
     for compiler in values.get("compilers", []):
         if "arch" in compiler:
             target_path = (


### PR DESCRIPTION
- Dependencies added as inline script metadata to `template.py`, used by compatible runners (like `uv run`)
- For Unix-like OSes, if `uv` is installed, the script can simply be run with `./template.py`
- Defaulted filename to `values.yml` if none is specified