### PR TITLE
Patch Clang for Switch

### DIFF
--- a/platforms/switch/clang-3.9.1/linux/Dockerfile
+++ b/platforms/switch/clang-3.9.1/linux/Dockerfile
@@ -25,6 +25,25 @@ RUN wget -O musl.zip https://github.com/open-ead/botw-lib-musl/archive/${MUSL_HA
 RUN unzip musl.zip
 RUN cp -r botw-lib-musl-${MUSL_HASH} /compilers/switch/clang-3.9.1/
 
+RUN apk add --no-cache patch
+
+ARG PATCH_REPO=https://github.com/GRAnimated/switch-clang-patches
+ARG PATCH_BRANCH=main
+
+RUN git clone --branch ${PATCH_BRANCH} ${PATCH_REPO} /tmp/patches
+
+# apply patches to clang
+WORKDIR /compilers/switch/clang-3.9.1
+RUN patch_dir="/tmp/patches/clang-3.9.1/include/c++/v1" && \
+    if [ -d "$patch_dir" ]; then \
+        find "$patch_dir" -type f -name '*.diff' -print0 | while IFS= read -r -d '' patch; do \
+            echo "Applying patch: $patch"; \
+            patch -p1 < "$patch"; \
+        done; \
+    fi
+
+RUN rm -rf /tmp/patches
+
 RUN chown -R root:root /compilers/switch/clang-3.9.1/
 
 

--- a/platforms/switch/clang-4.0.1/darwin/Dockerfile
+++ b/platforms/switch/clang-4.0.1/darwin/Dockerfile
@@ -25,6 +25,25 @@ RUN wget -O musl.zip https://github.com/open-ead/botw-lib-musl/archive/${MUSL_HA
 RUN unzip musl.zip
 RUN cp -r botw-lib-musl-${MUSL_HASH} /compilers/switch/clang-4.0.1/
 
+RUN apk add --no-cache patch
+
+ARG PATCH_REPO=https://github.com/GRAnimated/switch-clang-patches
+ARG PATCH_BRANCH=main
+
+RUN git clone --branch ${PATCH_BRANCH} ${PATCH_REPO} /tmp/patches
+
+# apply patches to clang
+WORKDIR /compilers/switch/clang-4.0.1
+RUN patch_dir="/tmp/patches/clang-4.0.1/include/c++/v1" && \
+    if [ -d "$patch_dir" ]; then \
+        find "$patch_dir" -type f -name '*.diff' -print0 | while IFS= read -r -d '' patch; do \
+            echo "Applying patch: $patch"; \
+            patch -p1 < "$patch"; \
+        done; \
+    fi
+
+RUN rm -rf /tmp/patches
+
 RUN chown -R root:root /compilers/switch/clang-4.0.1/
 
 

--- a/platforms/switch/clang-4.0.1/linux/Dockerfile
+++ b/platforms/switch/clang-4.0.1/linux/Dockerfile
@@ -25,6 +25,25 @@ RUN wget -O musl.zip https://github.com/open-ead/botw-lib-musl/archive/${MUSL_HA
 RUN unzip musl.zip
 RUN cp -r botw-lib-musl-${MUSL_HASH} /compilers/switch/clang-4.0.1/
 
+RUN apk add --no-cache patch
+
+ARG PATCH_REPO=https://github.com/GRAnimated/switch-clang-patches
+ARG PATCH_BRANCH=main
+
+RUN git clone --branch ${PATCH_BRANCH} ${PATCH_REPO} /tmp/patches
+
+# apply patches to clang
+WORKDIR /compilers/switch/clang-4.0.1
+RUN patch_dir="/tmp/patches/clang-4.0.1/include/c++/v1" && \
+    if [ -d "$patch_dir" ]; then \
+        find "$patch_dir" -type f -name '*.diff' -print0 | while IFS= read -r -d '' patch; do \
+            echo "Applying patch: $patch"; \
+            patch -p1 < "$patch"; \
+        done; \
+    fi
+
+RUN rm -rf /tmp/patches
+
 RUN chown -R root:root /compilers/switch/clang-4.0.1/
 
 

--- a/platforms/switch/clang-8.0.0/darwin/Dockerfile
+++ b/platforms/switch/clang-8.0.0/darwin/Dockerfile
@@ -25,6 +25,25 @@ RUN wget -O musl.zip https://github.com/open-ead/botw-lib-musl/archive/${MUSL_HA
 RUN unzip musl.zip
 RUN cp -r botw-lib-musl-${MUSL_HASH} /compilers/switch/clang-8.0.0/
 
+RUN apk add --no-cache patch
+
+ARG PATCH_REPO=https://github.com/GRAnimated/switch-clang-patches
+ARG PATCH_BRANCH=main
+
+RUN git clone --branch ${PATCH_BRANCH} ${PATCH_REPO} /tmp/patches
+
+# apply patches to clang
+WORKDIR /compilers/switch/clang-8.0.0
+RUN patch_dir="/tmp/patches/clang-8.0.0/include/c++/v1" && \
+    if [ -d "$patch_dir" ]; then \
+        find "$patch_dir" -type f -name '*.diff' -print0 | while IFS= read -r -d '' patch; do \
+            echo "Applying patch: $patch"; \
+            patch -p1 < "$patch"; \
+        done; \
+    fi
+
+RUN rm -rf /tmp/patches
+
 RUN chown -R root:root /compilers/switch/clang-8.0.0/
 
 

--- a/platforms/switch/clang-8.0.0/linux/Dockerfile
+++ b/platforms/switch/clang-8.0.0/linux/Dockerfile
@@ -25,6 +25,25 @@ RUN wget -O musl.zip https://github.com/open-ead/botw-lib-musl/archive/${MUSL_HA
 RUN unzip musl.zip
 RUN cp -r botw-lib-musl-${MUSL_HASH} /compilers/switch/clang-8.0.0/
 
+RUN apk add --no-cache patch
+
+ARG PATCH_REPO=https://github.com/GRAnimated/switch-clang-patches
+ARG PATCH_BRANCH=main
+
+RUN git clone --branch ${PATCH_BRANCH} ${PATCH_REPO} /tmp/patches
+
+# apply patches to clang
+WORKDIR /compilers/switch/clang-8.0.0
+RUN patch_dir="/tmp/patches/clang-8.0.0/include/c++/v1" && \
+    if [ -d "$patch_dir" ]; then \
+        find "$patch_dir" -type f -name '*.diff' -print0 | while IFS= read -r -d '' patch; do \
+            echo "Applying patch: $patch"; \
+            patch -p1 < "$patch"; \
+        done; \
+    fi
+
+RUN rm -rf /tmp/patches
+
 RUN chown -R root:root /compilers/switch/clang-8.0.0/
 
 

--- a/templates/switch/clang.j2
+++ b/templates/switch/clang.j2
@@ -24,6 +24,25 @@ RUN wget -O musl.zip https://github.com/open-ead/botw-lib-musl/archive/${MUSL_HA
 RUN unzip musl.zip
 RUN cp -r botw-lib-musl-${MUSL_HASH} /compilers/{{ platform }}/{{ id }}/
 
+RUN apk add --no-cache patch
+
+ARG PATCH_REPO=https://github.com/GRAnimated/switch-clang-patches
+ARG PATCH_BRANCH=main
+
+RUN git clone --branch ${PATCH_BRANCH} ${PATCH_REPO} /tmp/patches
+
+# apply patches to clang
+WORKDIR /compilers/{{ platform }}/{{ id }}
+RUN patch_dir="/tmp/patches/{{ id }}/include/c++/v1" && \
+    if [ -d "$patch_dir" ]; then \
+        find "$patch_dir" -type f -name '*.diff' -print0 | while IFS= read -r -d '' patch; do \
+            echo "Applying patch: $patch"; \
+            patch -p1 < "$patch"; \
+        done; \
+    fi
+
+RUN rm -rf /tmp/patches
+
 RUN chown -R root:root /compilers/{{ platform }}/{{ id }}/
 
 


### PR DESCRIPTION
The Switch uses Clang for compiling, but makes some modifications to the STL that we need to replicate to match some code.

Instead of shipping a custom modified zip of clang (from a slower mirror than LLVM), and having to update the zip when we make any new patches, this .diff system should let us add new patches without having to update the compilers repository.

These changes are required to compile/match some scratches on decomp.me.
