### PR TITLE
Add modern-asn64.py to gcc2.8.1sn compiler

### DIFF
--- a/platforms/n64/gcc2.8.1sn/Dockerfile
+++ b/platforms/n64/gcc2.8.1sn/Dockerfile
@@ -10,6 +10,7 @@ RUN wget -O /compilers/n64/gcc2.8.1sn/cc1n64.exe "https://github.com/marijnvdwer
 RUN wget -O /compilers/n64/gcc2.8.1sn/cc1pln64.exe "https://github.com/marijnvdwerf/sn64/releases/download/1%2C0%2C0%2C2/cc1pln64.exe"
 RUN wget -O psyq-obj-parser.tar.gz "https://github.com/decompme/compilers/releases/download/compilers/psyq-obj-parser.tar.gz"
 RUN tar xvzf psyq-obj-parser.tar.gz -C /compilers/n64/gcc2.8.1sn
+RUN wget -O /compilers/n64/gcc2.8.1sn/modern-asn64.py "https://github.com/RocketRet/modern-asn64/releases/download/main-release/modern-asn64.py"
 
 RUN chown -R root:root /compilers/n64/gcc2.8.1sn/
 RUN chmod +x /compilers/n64/gcc2.8.1sn/*

--- a/values.yaml
+++ b/values.yaml
@@ -72,6 +72,7 @@ compilers:
       - https://github.com/marijnvdwerf/sn64/releases/download/1%2C0%2C0%2C2/cc1n64.exe
       - https://github.com/marijnvdwerf/sn64/releases/download/1%2C0%2C0%2C2/cc1pln64.exe
       - https://github.com/decompme/compilers/releases/download/compilers/psyq-obj-parser.tar.gz
+      - https://github.com/RocketRet/modern-asn64/releases/download/main-release/modern-asn64.py
 
   - id: ido5.3
     platform: n64


### PR DESCRIPTION
## Summary
- Adds modern-asn64.py script to gcc2.8.1sn compiler Dockerfile
- This enables the gcc2.8.1snew-cxx compiler variant to work correctly
- Follows the same pattern used in gcc2.7.2snew compiler

## Motivation
The gcc2.8.1snew-cxx compiler requires modern-asn64.py to function properly, but it wasn't included in the gcc2.8.1sn base compiler package. This PR adds the missing dependency.

## Changes
- Downloads modern-asn64.py from https://github.com/RocketRet/modern-asn64/releases/download/main-release/modern-asn64.py during Docker build

🤖 Generated with [Claude Code](https://claude.ai/code)